### PR TITLE
Use resources instead of filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Directory of Azure Functions output
+/output/

--- a/UpdateLatestImageWithLabel.cs
+++ b/UpdateLatestImageWithLabel.cs
@@ -29,10 +29,18 @@ namespace Grow.Update
             var containerName = "images";
             var latestFileName = "latest.jpg";
 
-            FontCollection collection = new();
-            var family = collection.Add("assets/NotoSansMono-Regular.ttf");
-            var font = family.CreateFont(12, FontStyle.Regular);
+            var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+            var resource = assembly.GetManifestResourceStream("growing_image_sync.assets.NotoSansMono-Regular.ttf");
 
+            if (resource == null)
+            {
+                Console.WriteLine($"Unable to find font for rendering, exiting...");
+                Environment.Exit(0);
+            }
+
+            FontCollection collection = new();
+            var family = collection.Add(resource);
+            var font = family.CreateFont(12, FontStyle.Regular);
 
             var connectionString = Environment.GetEnvironmentVariable("BLOB_STORAGE_CONNECTION_STRING");
             if (string.IsNullOrWhiteSpace(connectionString))

--- a/growing-image-sync.csproj
+++ b/growing-image-sync.csproj
@@ -28,10 +28,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
-    <None Update="assets/NotoSansMono-Regular.ttf">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
+    <EmbeddedResource Include="assets/NotoSansMono-Regular.ttf" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />


### PR DESCRIPTION
This should workaround a limitation with Azure Functions that I don't fully understand:

> `Result: Failure Exception: System.IO.DirectoryNotFoundException: Could not find a part of the path '/tmp/functions\standby\wwwroot/assets/NotoSansMono-Regular.ttf'. at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError) at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func``4 createOpenException) ... `

I think [Zip Deploy](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies?tabs=windows#zip-deploy) means the resources we use aren't on disk, and I'm going to use a trick from back in the day and embed the font as a resource in the assembly. 

This requires some lookups but I've also added a check to exit gracefully if the resource doesn't work (but I tested this locally to ensure I got the name right).
