### PR TITLE
introduce a simpler watermark function

### DIFF
--- a/UpdateLatestImageWithLabel.cs
+++ b/UpdateLatestImageWithLabel.cs
@@ -82,8 +82,7 @@ namespace Grow.Update
 
                 using (Image img = Image.Load(initialStream))
                 {
-                    img.Mutate(ctx => ApplyToImage(ctx, font, humanFriendlyTime, Color.White, 10, firstRow: true));
-                    img.Mutate(ctx => ApplyToImage(ctx, font, humanFriendlyDate, Color.White, 10));
+                    img.Mutate(ctx => ApplyTimestamp(ctx, font, humanFriendlyTime, humanFriendlyDate, Color.White, 10));
                     img.Save(streamForUploading, new JpegEncoder());
                 }
 


### PR DESCRIPTION
This PR throws away the computation work to determine the scaled font to use, and sets a hard-coded value because the images are always the same size.

This also unifies both lines so it goes back to being a one-liner - I haven't looked into whether it's more efficent to do multiple `DrawText` calls within the one `Mutate` but I suspect it is.

Benchmark of before/after:

```
$ dotnet run -c Release
First approach took 246ms
Second approach took 81ms
```